### PR TITLE
Add a fix to a breaking change introduced in PHP 8 for the call_user_func_array() function.

### DIFF
--- a/src/ShortcodeManager.php
+++ b/src/ShortcodeManager.php
@@ -380,7 +380,7 @@ class ShortcodeManager implements ShortcodeManagerInterface {
 	protected function instantiate( $interface, $class, array $args ) {
 		try {
 			if ( is_callable( $class ) ) {
-				$class = call_user_func_array( $class, $args );
+				$class = call_user_func_array( $class, array_values( $args ) );
 			}
 
 			if ( is_string( $class ) ) {


### PR DESCRIPTION
Closes [Issue-28](https://github.com/brightnucleus/shortcodes/issues/28)

This PR passes the second parameter to `call_user_func_array()` via `array_values()` so you don't have keys that are treated as named parameters.